### PR TITLE
Test enhancement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ php:
   - '5.5'
   - '5.6'
   - '7.0'
+  - '7.1'
+  - '7.2'
 install:
   - composer install
 script:

--- a/composer.json
+++ b/composer.json
@@ -17,15 +17,15 @@
     ],
     "require": {
         "php": ">=5.5",
-        "guzzlehttp/guzzle": "~6.2",
-        "glicer/simply-html": "~1.0",
-        "symfony/finder": "~2.3 || ~3.0",
-        "symfony/console": "~2.3 || ~3.0"
+        "guzzlehttp/guzzle": "^6.2",
+        "glicer/simply-html": "^1.0",
+        "symfony/finder": "^2.3 || ^3.0",
+        "symfony/console": "^2.3 || ^3.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~4.0",
-        "symfony/process": "~2.3 || ~3.0",
-        "satooshi/php-coveralls": "~1.0"
+        "phpunit/phpunit": "^4.8 || ^5.7 || ^6.5",
+        "symfony/process": "^2.3 || ^3.0",
+        "php-coveralls/php-coveralls": "^2.0"
     },
     "autoload": {
         "psr-4": {

--- a/tests/GlLinkCheckerErrorTest.php
+++ b/tests/GlLinkCheckerErrorTest.php
@@ -20,28 +20,28 @@ namespace GlLinkChecker\Tests;
 
 use GlLinkChecker\GlLinkCheckerError;
 use GuzzleHttp\Client;
-
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers        \GlLinkChecker\GlLinkCheckerError
  * @backupGlobals disabled
  */
-class GlLinkCheckerErrorTest extends \PHPUnit_Framework_TestCase
+class GlLinkCheckerErrorTest extends TestCase
 {
     public function testConstruct()
     {
         $client = new Client();
         $linkerror = new GlLinkCheckerError($client,'http://dev.glicer.com',['file1','file2']);
-        
+
         $this->assertEquals('http://dev.glicer.com', $linkerror->getLink());
         $this->assertEquals(['file1','file2'], $linkerror->getFiles());
     }
 
-    public function testCheck() 
+    public function testCheck()
     {
         $client = new Client();
         $linkerror = new GlLinkCheckerError($client, 'http://dev.glicer.com',['index.html']);
-        
+
         $linkerror->check(['exist','endslash','absolute','lowercase']);
     }
 }


### PR DESCRIPTION
# Changed log
- Using the class-based PHPUnit namespace to be compatible with latest PHPUnit version.
- Using the `^` to define required package version in `composer.json`.
- Add other test methods.
- Remove additional white space.
- Add `php-7.1` and `php-7.2` tests in Travis CI build.