### PR TITLE
Fixing issue #7 for urls not ending with `/`

### DIFF
--- a/src/GlLinkChecker.php
+++ b/src/GlLinkChecker.php
@@ -227,7 +227,7 @@ class GlLinkChecker
      * @throws \Exception
      * @return GlLinkCheckerError[]
      */
-    public function checkFiles(Finder $files, callable $checkstart, callable $checking, callable $checkend)
+    public function checkFiles(Finder $files, callable $checkstart, callable $checking, callable $checkend, Array $criterias = ['lowercase', 'endslash', 'absolute'])
     {
         $linksByFile = [];
         /**
@@ -270,7 +270,7 @@ class GlLinkChecker
             $gllink = new GlLinkCheckerError($this->client, $link, $files);
 
             if ($gllink->isInternal($this->internalurls)) {
-                $gllink->check(['lowercase', 'endslash', 'absolute']);
+                $gllink->check($criterias);
             }
 
             $gllink->check(['exist']);

--- a/tests/GlLinkCheckerTest.php
+++ b/tests/GlLinkCheckerTest.php
@@ -130,9 +130,9 @@ class GlLinkCheckerTest extends \PHPUnit_Framework_TestCase
             $links[] = $link->getLink();
         }
 
-        $this->validatelink("https://ucarecdn.com/b7b8d79f-537b-4c9b-b4c3-e055556c2676/", $links,$result, ['absolute' => true, 'lowercase' => true, 'exist' => true, 'notendslash' => true]);
-        $this->validatelink("https://breatheco.de/en/lesson-asset/html5-cheat-shet/", $links, $result, ['absolute' => true, 'lowercase' => true, 'exist' => false, 'notendslash' => true]);
-        $this->validatelink("https://ucarecdn.com/8729c2f0-e4a6-4721-9ee9-3f29e6e852b5/", $links, $result, ['absolute' => true, 'lowercase' => true, 'exist' => true, 'notendslash' => true]);
+        $this->validatelink("https://ucarecdn.com/aa1a5994-8de9-4d24-99ce-3a0d686c30bd/-/resize/700x/", $links,$result, ['absolute' => true, 'lowercase' => true, 'exist' => true, 'notendslash' => true]);
+        $this->validatelink("https://projects.breatheco.de/d/landing-page-with-react#readme", $links, $result, ['absolute' => true, 'lowercase' => true, 'exist' => true, 'notendslash' => false]);
+        $this->validatelink("https://ucarecdn.com/8729c2f0-e4a6-4721-9ee9-3f29e6e852b5/", $links, $result, ['absolute' => true, 'lowercase' => true, 'exist' => false, 'notendslash' => true]);
     }
     
     public function testLinks()

--- a/tests/md/example.md
+++ b/tests/md/example.md
@@ -21,7 +21,7 @@ HTML makes you divide the website information into parts – similar to the basi
 
 Originally browsers only knew how to interpret HTML.  Websites were simple and neither CSS or JavaScript was used.  A website was a simple plain text document with the typical elements any Word Document has: Headings, Bullet lists, Paragraphs, etc.
 
-![buildinghtml](https://ucarecdn.com/b7b8d79f-537b-4c9b-b4c3-e055556c2676/)
+![buildinghtml](https://ucarecdn.com/aa1a5994-8de9-4d24-99ce-3a0d686c30bd/-/resize/700x/)
 
 
 All tags must open and close.  To close a tag you must place the same word but using the `/` symbol.
@@ -35,7 +35,7 @@ Once the `<tag>` is defined, we can describe in detail its behavior by assigning
 ```
 
 
-In theory, you have to use [one of these tags](https://breatheco.de/en/lesson-asset/html5-cheat-shet/) and don’t invent your own because the browser won’t know how to interpret them.  You must learn what each tag means and does in order to put them to good use…but, please, don’t worry!   There aren’t that many! 🙂
+In theory, you have to use [one of these tags](https://projects.breatheco.de/d/landing-page-with-react#readme) and don’t invent your own because the browser won’t know how to interpret them.  You must learn what each tag means and does in order to put them to good use…but, please, don’t worry!   There aren’t that many! 🙂
 
 For the main heading of the document, the tag that we use is `<h1>`.  For example: An online store has an "electronics" category, the title that applies would be "Electronics" and the `<h1>` tag would be written as follows:
 


### PR DESCRIPTION
By default the 3 validations remain the same, but now you can pass a 4th aprameter on the checkFiles function specifying the validations you would want. For example:

This will check markdown files and validate lowercase and absolute paths, but it won't matter if they don't finish in slash.

    //construct list of local html and json files to check
    $finder = new Finder();
    $files  = $finder->files()
                ->in('./p')
                ->name("*.md");
    
    //launch links checking
    $result  = $linkChecker->checkFiles(
        $files,
        function ($nbr) {
            // called at beginning - $nbr urls to check
        },
        function ($url, $files) {
            // called each $url - $files : list of filename containing $url link
        },
        function () {
            // called at the end
        },
        ['lowercase', 'endslash', 'absolute']
    );